### PR TITLE
Add dynamic_controls page object and spec

### DIFF
--- a/test/pageobjects/dynamic_controls.page.js
+++ b/test/pageobjects/dynamic_controls.page.js
@@ -1,0 +1,29 @@
+/**
+ * Created by billagee on 2/5/17.
+ */
+var page = require('./page')
+
+var dynamicControlsPage = Object.create(page, {
+    /**
+     * define elements
+     */
+    btnRemove: { get: function () { return browser.element('button=Remove'); } },
+    btnAdd: { get: function () { return browser.element('button=Add'); } },
+    checkboxFoo: {
+        get: function () { return browser.element("input[type='checkbox']"); }
+    },
+    pItsGone : {
+        get: function () {
+            return browser.element('//p[@id="message" and .="It\'s gone!"]');
+        }
+    },
+
+    /**
+     * define or overwrite page methods
+     */
+    open: { value: function() {
+        page.open.call(this, 'dynamic_controls');
+    } }
+});
+
+module.exports = dynamicControlsPage

--- a/test/specs/dynamic_controls/dynamic_controls.spec.js
+++ b/test/specs/dynamic_controls/dynamic_controls.spec.js
@@ -1,0 +1,19 @@
+/**
+ * Created by billagee on 2/5/17.
+ */
+var expect = require('chai').expect;
+var DynamicControlsPage = require('../../pageobjects/dynamic_controls.page');
+
+describe('The dynamic controls page', function () {
+    it('should remove a checkbox after the Remove button is pressed', function () {
+        DynamicControlsPage.open();
+        // The checkbox should exist on page load
+        expect(DynamicControlsPage.checkboxFoo.isExisting()).to.equal(true);
+        DynamicControlsPage.btnRemove.click();
+        // Check that the checkbox is removed within 10 seconds, the
+        // Add button appears, and the "It's gone!" message appeared
+        DynamicControlsPage.checkboxFoo.waitForExist(10000, reverse=true);
+        DynamicControlsPage.btnAdd.waitForExist();
+        DynamicControlsPage.pItsGone.waitForExist();
+    });
+});


### PR DESCRIPTION
Added files to cover https://the-internet.herokuapp.com/dynamic_controls

When running this new test with Safari 10, I ran into an issue waiting for the checkbox in the page to appear - not sure yet if Safari generally has problems with webdriver.io code that works in Chrome and FF...